### PR TITLE
adding HTML comment about latest CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
 			<p>Uh-oh! Something went wrong with your request. Here's what we know:</p>
 		</div>
 	</div>
+	<!-- handy way of loading the most recent version of jQuery but DO NOT USE THIS IN PRODUCTION it will only be cached for ~10 minutes. Instead use a minified and versioned link found at https://code.jquery.com -->
 	<script src="http://code.jquery.com/jquery-latest.min.js"></script>
 	<script src="js/app.js"></script>
 </body>


### PR DESCRIPTION
handy way of loading the most recent version of jQuery but DO NOT USE
THIS IN PRODUCTION it will only be cached for ~10 minutes. Instead use
a minified and versioned link found at https://code.jquery.com
